### PR TITLE
Fix Undefined index HTTP_HOST in CLI environment

### DIFF
--- a/src/PayonHelper.php
+++ b/src/PayonHelper.php
@@ -30,7 +30,11 @@ class PayonHelper
         $this->http_auth = $http_auth;
         $this->http_auth_pass = $http_auth_pass;
         $this->ssl_verifypeer = $ssl_verifypeer;
-        $url_base = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https" : "http") . "://$_SERVER[HTTP_HOST]";
+        $url_base = sprintf(
+            '%s://%s',
+            (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http',
+            isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : (gethostname() ?: 'localhost')
+        );
         $this->ref_code = 'MCAPI-LV-'. $url_base;
     }
 


### PR DESCRIPTION
## Description of changes
Fixed the `Undefined index: HTTP_HOST` error when working in CLI mode (for example, when running php artisan commands).

### Changes:
- Added a check for the existence of `HTTP_HOST`
- Added fallback to `gethostname()` or `localhost` for CLI mode
- Maintained backward compatibility with PHP 5.6+

### Testing:
Tested in:
- Web mode (with `HTTP_HOST`)
- CLI mode (php artisan commands)
### Error:
![изображение](https://github.com/user-attachments/assets/9bffb2bf-32d9-47b2-8dd8-4b5dafda7d23)
